### PR TITLE
#58 Fixed issue where Portacle Launcher hangs on font change...

### DIFF
--- a/src/portacle_win.c
+++ b/src/portacle_win.c
@@ -120,6 +120,6 @@ int add_font(char *file){
 }
 
 int reg_fonts(){
-  SendMessage(HWND_BROADCAST, WM_FONTCHANGE, 0, 0);
+  SendNotifyMessage(HWND_BROADCAST, WM_FONTCHANGE, 0, 0);
   return 1;
 }


### PR DESCRIPTION
...message broadcast

This seems to fix the issue with `SendMessage()` hanging up. It now calls `SendNotifyMessage()` instead.

For more info see https://stackoverflow.com/questions/1951658/sendmessagehwnd-broadcast-hangs