### PR TITLE
Windows compiler warnings

### DIFF
--- a/src/portacle_win.c
+++ b/src/portacle_win.c
@@ -120,6 +120,6 @@ int add_font(char *file){
 }
 
 int reg_fonts(){
-  SendMessage(HWND_BROADCAST, WM_FONTCHANGE, 0, 0);
+  SendNotifyMessage(HWND_BROADCAST, WM_FONTCHANGE, 0, 0);
   return 1;
 }

--- a/src/portacle_win.c
+++ b/src/portacle_win.c
@@ -1,3 +1,4 @@
+#include <winsock2.h>
 #include <windows.h>
 #include <shellapi.h>
 #include <shlwapi.h>
@@ -64,6 +65,7 @@ int qcat(char *target, int offset, char *arg){
 
 int win_create_flags = 0;
 int launch(char *path, int argc, char **argv){
+  DWORD code = 0;
   PROCESS_INFORMATION process_info = {0};
   STARTUPINFO startup_info = {0};
 
@@ -97,7 +99,8 @@ int launch(char *path, int argc, char **argv){
     return 0;
   // Wait for process to exit.
   WaitForSingleObject(process_info.hProcess, INFINITE);
-  GetExitCodeProcess(process_info.hProcess, &exitCode);
+  GetExitCodeProcess(process_info.hProcess, &code);
+  exitCode = code;
   CloseHandle(process_info.hProcess);
   CloseHandle(process_info.hThread);
   return 1;


### PR DESCRIPTION
Fixed compiler warnings that appear in Windows while compiling via a mingw64 console.

winsock2.h is included further down the header include line but it should be included *before* windows.h so it causes a warning.

`GetExitCodeProcess()` wants a pointer to a DWORD which is commonly an `unsigned long int` but exitCode is a `signed int` thus causing a warning.

This pull request fixes these two.